### PR TITLE
Fix handle lookups.

### DIFF
--- a/src/osi/windows/windows_handles.cc
+++ b/src/osi/windows/windows_handles.cc
@@ -14,19 +14,25 @@
 // the resolve functions in this file are based off of ReactOS
 // https://doxygen.reactos.org/d0/d72/ex_8h.html#a1fa10d89ce5eb73bd55ed2cd2001d38a
 
-uint64_t resolve_base_x64(uint64_t value, uint32_t level, uint64_t base)
+uint64_t resolve_base_x64(struct WindowsProcessOSI *posi, uint64_t value, uint32_t level, uint64_t base)
 {
     static_offsets::amd64::EXHANDLE_PARTIAL handle_obj;
     handle_obj.handle = value;
     handle_obj.TagBits = 0;
 
     switch (level) {
-    case 2:
+    case 2: {
         base = base + (sizeof(uint64_t) * handle_obj.HighIndex);
+        auto obj = osi::i_t(posi->vmem, posi->tlib, base, "UNKNOWN");
+        base = obj.get64();
         // fall through
-    case 1:
+    }
+    case 1: {
         base = base + (sizeof(uint64_t) * handle_obj.MidIndex);
+        auto obj = osi::i_t(posi->vmem, posi->tlib, base, "UNKNOWN");
+        base = obj.get64();
         // fall through
+    }
     case 0:
         base = base + (handle_obj.LowIndex * HANDLE_ENTRY_SIZE_64);
         break;
@@ -36,19 +42,24 @@ uint64_t resolve_base_x64(uint64_t value, uint32_t level, uint64_t base)
     return base;
 }
 
-uint32_t resolve_base_x86(uint32_t value, uint32_t level, uint32_t base)
+uint32_t resolve_base_x86(struct WindowsProcessOSI *posi, uint32_t value, uint32_t level, uint32_t base)
 {
     static_offsets::i386::EXHANDLE_PARTIAL handle_obj;
     handle_obj.handle = value;
-    handle_obj.TagBits = 0;
 
     switch (level) {
-    case 2:
+    case 2: {
         base = base + (sizeof(uint32_t) * handle_obj.HighIndex);
+        auto obj = osi::i_t(posi->vmem, posi->tlib, base, "UNKNOWN");
+        base = obj.get32();
         // fall through
-    case 1:
+    }
+    case 1: {
         base = base + (sizeof(uint32_t) * handle_obj.MidIndex);
+        auto obj = osi::i_t(posi->vmem, posi->tlib, base, "UNKNOWN");
+        base = obj.get32();
         // fall through
+    }
     case 0:
         base = base + (handle_obj.LowIndex * HANDLE_ENTRY_SIZE_32);
         break;
@@ -71,14 +82,14 @@ osi::i_t resolve_handle_table_entry(struct WindowsProcessOSI* posi, uint64_t han
 
     uint64_t entry = 0;
     if (x64) {
-        entry = resolve_base_x64(handle, table_level, table_base);
+        entry = resolve_base_x64(posi, handle, table_level, table_base);
     } else {
         if (handle > 0xffffffff) {
             fprintf(stderr, "Cannot look up 64 bit value as 32 bit handle\n");
             return osi::i_t();
         }
 
-        entry = resolve_base_x86(static_cast<uint32_t>(handle), table_level,
+        entry = resolve_base_x86(posi, static_cast<uint32_t>(handle), table_level,
                                  static_cast<uint32_t>(table_base));
     }
 
@@ -97,7 +108,7 @@ osi::i_t resolve_handle_table_entry_win2000(struct WindowsProcessOSI* posi,
     // TODO: verify that all entries are actually level 3? This was added
     // as panda-re/panda does this for windows 2k
 
-    uint64_t entry = resolve_base_x86(handle, 2, table_base);
+    uint64_t entry = resolve_base_x86(posi, handle, 2, table_base);
     uint64_t header = obj.set_address(entry).getu();
 
     // The lock flag must be set to get a valid ptr


### PR DESCRIPTION
The handle layers are arrays of pointers.
After indexing into a handle table, the element must be dereferenced to
get the pointer to the start of the next handle layer array.

Found this when testing the new wintrospection plugin with our regression suite.
The file_taint plugin wasn't working with a windows 2000 guest.
Discovered that get_handle_name in windows_read_enter in the file taint plugin was always returning "unknown".

Updated resolve_base_x86 to iterate through the handle tables resolved the issue.
I've only tested with windows 2000 but I suspect this affects all versions of windows.  I made the equivalent change to resolve_base_x64.

