### PR TITLE
Add alternatives for get_module_list.

### DIFF
--- a/include/osi/windows/wintrospection.h
+++ b/include/osi/windows/wintrospection.h
@@ -72,6 +72,14 @@ void free_process(struct WindowsProcess*);
 const uint8_t MODULELIST_LOAD_ORDER = 0;
 struct WindowsModuleList* get_module_list(struct WindowsKernelOSI* kosi, uint64_t address,
                                           bool iswow);
+struct WindowsModuleEntry* get_module_by_addr(struct WindowsKernelOSI* kosi,
+                                              uint64_t process_address, bool is_wow64,
+                                              uint64_t addr);
+uint64_t get_module_base_address_by_name(struct WindowsKernelOSI* kosi,
+                                         uint64_t process_address, bool is_wow64,
+                                         const char* name);
+bool has_module_prefix(struct WindowsKernelOSI* kosi, uint64_t process_address,
+                       bool is_wow64, const char* prefix);
 struct WindowsModuleEntry* module_list_next(struct WindowsModuleList*);
 struct WindowsProcessOSI* module_list_get_osi(struct WindowsModuleList* mlist);
 void free_module_list(struct WindowsModuleList* mlist);


### PR DESCRIPTION
get_module_list is overkill for some use cases.  If a caller is only interested in a particular module, get_module_list does a lot of work, most of which will be ignored by the caller.

Refactored api.cc a bit to allow it to be easily extended to add alternatives to get_module_list.  Included three new API methods:

get_module_by_addr - returns a WindowsModuleEntry * for a specific address. Useful to get the module entry for the current program counter.

get_module_base_address_by_name - Returns the base address for a specific module.

has_module_prefix - Returns true if a module is loaded whose name matches a specific prefix.

Using the new framework more tailored use cases could be added in the future.

If I did this right, this should be completely backward compatible with the previous version.

I'm working an update to PANDA OSI to make use of these new API calls.