### PR TITLE
Updating LibOsi actions because the one used is EOL

### DIFF
--- a/.github/workflows/publish_deb.yml
+++ b/.github/workflows/publish_deb.yml
@@ -8,22 +8,17 @@ on:
 jobs:
   create_release:
     runs-on: ubuntu-latest
+
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      v-version: ${{ steps.version.outputs.v-version }}
+
     steps:
       - name: Get next version
-        uses: reecetech/version-increment@2023.10.1
+        uses: reecetech/version-increment@2023.10.2
         id: version
         with:
+          release_branch: master
           use_api: true
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: ${{ steps.version.outputs.version }}
 
   build_deb_2004:
     needs: create_release
@@ -40,16 +35,15 @@ jobs:
         working-directory: .
         run: mkdir build && cd build && cmake -GNinja .. && ninja && ninja package
 
-      - name: Upload to release
-        uses: actions/upload-release-asset@v1
+      - name: Upload debian package to release
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: build/libosi-0.1.1-Linux.deb
-          asset_name: libosi_20.04.deb
-          asset_content_type: application/vnd.debian.binary-package
-          
+          tag_name: ${{ needs.create_release.outputs.v-version }}
+          files: |
+            build/*.deb
+
   build_deb_2204:
     needs: create_release
     runs-on: ubuntu-22.04
@@ -65,12 +59,11 @@ jobs:
         working-directory: .
         run: mkdir build && cd build && cmake -GNinja .. && ninja && ninja package
 
-      - name: Upload to release
-        uses: actions/upload-release-asset@v1
+      - name: Upload debian package to release
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: build/libosi-0.1.1-Linux.deb
-          asset_name: libosi_22.04.deb
-          asset_content_type: application/vnd.debian.binary-package
+          tag_name: ${{ needs.create_release.outputs.v-version }}
+          files: |
+            build/*.deb

--- a/CPackConfig.txt
+++ b/CPackConfig.txt
@@ -1,3 +1,11 @@
+# Check if the system is Ubuntu
+execute_process(COMMAND bash -c "if grep -q Ubuntu /etc/issue; then echo 'Ubuntu'; else echo 'NotUbuntu'; fi"
+                OUTPUT_VARIABLE UBUNTU_CHECK
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Print the result of the Ubuntu check
+message(STATUS "Ubuntu check result: ${UBUNTU_CHECK}")
+
 set(CPACK_PACKAGE_NAME "libosi")
 set(CPACK_PACKAGE_DESCRIPTION "Operating System Introspection Support for PANDA plugins")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Operating System Introspection Support for PANDA plugins")
@@ -20,6 +28,14 @@ set(CPACK_GENERATOR "DEB")
 set(CPACK_SOURCE_GENERATOR "TGZ")
 
 set(CPACK_SOURCE_IGNORE_FILES "^${CMAKE_BINARY_DIR};/\\\\.gitignore;/\\\\.svn;\\\\.swp$;\\\\.#;/#;.*~")
+
+# Conditionally set the package file name if on Ubuntu
+if(UBUNTU_CHECK STREQUAL "Ubuntu")
+    execute_process(COMMAND lsb_release -r -s
+                    OUTPUT_VARIABLE UBUNTU_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${UBUNTU_VERSION}")
+endif()
 
 include(CPack)
 


### PR DESCRIPTION
This is an updated version of PR #12 that
1) Leaves CI as running on `ubuntu-latest`
2) Squashes the changes into a single commit
3) Drops trailing whitespace


I had previously merged #12 without squashing (which I meant to do) but then it broke the build because of point 1 in here. I force-pushed to `master` to drop those commits 🙈 and am now pulling them in here.


This code was written by @AndrewQuijano. 