### PR TITLE
Run ldconfig and add testing in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure Unix-style line endings for the triggers file
+triggers text eol=lf

--- a/.github/workflows/publish_deb.yml
+++ b/.github/workflows/publish_deb.yml
@@ -1,14 +1,14 @@
-name: Publish deb package
+name: Publish LibOSI debian package
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      master
+      - master
 
 jobs:
   create_release:
     runs-on: ubuntu-latest
-
     outputs:
       v-version: ${{ steps.version.outputs.v-version }}
 
@@ -20,49 +20,27 @@ jobs:
           release_branch: master
           use_api: true
 
-  build_deb_2004:
+  build_and_publish:
     needs: create_release
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Install git
-        run: sudo apt-get -qq update -y && sudo apt-get -qq install cmake ninja-build rapidjson-dev -y
-
-      - name: Check out
-        uses: actions/checkout@v4
-
-      - name: Build package
-        working-directory: .
-        run: mkdir build && cd build && cmake -GNinja .. && ninja && ninja package
-
-      - name: Upload debian package to release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.create_release.outputs.v-version }}
-          files: |
-            build/*.deb
-
-  build_deb_2204:
-    needs: create_release
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get -qq update -y && sudo apt-get -qq install cmake ninja-build rapidjson-dev -y
+        run: |
+          sudo apt-get -qq update -y
+          sudo apt-get -qq install cmake ninja-build rapidjson-dev libgtest-dev libglib2.0-dev -y
 
       - name: Check out
         uses: actions/checkout@v4
 
       - name: Build package
-        working-directory: .
         run: | 
-          mkdir build
-          cd build
-          cmake -GNinja .. -DVERSION=${{ needs.create_release.outputs.v-version }}
-          ninja
-          ninja package
+          cmake -B build -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DVERSION=${{ needs.create_release.outputs.v-version }}
+          ninja -C build
+          ninja -C build package
 
       - name: Upload debian package to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test_libosi.yml
+++ b/.github/workflows/test_libosi.yml
@@ -1,0 +1,29 @@
+name: Test LibOSI library
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test_libosi:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get -qq update -y
+          sudo apt-get -qq install cmake ninja-build rapidjson-dev libgtest-dev libglib2.0-dev -y
+
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Build with testing enabled and run tests
+        run: | 
+          cmake -B build -GNinja -DENABLE_TESTING=ON
+          ninja -C build
+          ninja -C build test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
 project(libosi)
+include(GNUInstallDirs)
 
-cmake_minimum_required(VERSION 3.0.2)
-
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -112,13 +112,15 @@ target_link_libraries(osi offset ${GLIB_PKG_LIBRARIES})
 
 # Install everything
 install(TARGETS osi osi-static offset offset-static iohal iohal-static
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Install the headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-    DESTINATION include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h")
 
 if (ENABLE_TESTING)

--- a/CPackConfig.txt
+++ b/CPackConfig.txt
@@ -34,5 +34,7 @@ if(UBUNTU_CHECK STREQUAL "Ubuntu")
     set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${UBUNTU_VERSION}")
 endif()
 
-include(CPack)
+# Include additional control files
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/triggers")
 
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -18,26 +18,25 @@ Currently, the following profiles are supported:
 
 ### Easy mode (apt releases)
 
-See our releases page for the latest CI generated deb packages for Ubuntu 20.04 and 22.04.
+See our releases page for the latest CI generated deb packages for Ubuntu 22.04 and 24.04.
 
 ### Prerequisites
 
 Install dependencies. On Ubuntu, this can be done with:
 
 ```bash
-sudo apt-get update
-
-sudo apt-get install cmake ninja-build rapidjson-dev
+sudo apt-get update -y
+sudo apt-get install cmake ninja-build rapidjson-dev libglib2.0-dev -y
 ```
+Note that `libglib2.0-dev` is required only for Ubuntu 24.
 
 ### Building
 
 To build libosi, from the root of this repo run:
 
 ```bash
-mkdir build && cd $_
-cmake -GNinja ..
-ninja
+cmake -B build -GNinja -DCMAKE_INSTALL_PREFIX=/usr
+ninja -C build
 ```
 
 ### Installing
@@ -45,24 +44,21 @@ ninja
 Installing libosi includes running:
 
 ```bash
-cd build && ninja package
-sudo dpkg -i libosi-[version].deb
+ninja -C build package
+sudo dpkg -i build/libosi*.deb
 ```
 
 ### Testing
 
 Testing is currently implemented for offset and iohal. To run the tests, you will 
-first need to install dependencies and enable testing:
+first need to install dependencies and run the following commands to execute all the tests:
 
 ```bash
-sudo apt-get install libgtest-dev
-
-cd build
-cmake -GNinja -DENABLE_TESTING=ON ..
-ninja
+sudo apt-get install libgtest-dev -y
+cmake -B build -GNinja -DENABLE_TESTING=ON
+ninja -C build
+ninja -C build test
 ```
-
-You can then run the tests with just `ninja test`.
 
 ### Development 
 

--- a/triggers
+++ b/triggers
@@ -1,0 +1,2 @@
+# Trigger ldconfig after install
+activate-noawait ldconfig


### PR DESCRIPTION
I think you still need to run `ldconfig` after installing libosi to use the shared libraries, so I might as well enforce this when running the Debian Package.

Proof this works

https://github.com/AndrewQuijano/libosi/releases/tag/v0.0.1
https://github.com/AndrewQuijano/libosi/actions/runs/12458020130/job/34773177988

P. S. Adding Ubuntu 24, while the CI is SLOW, it seems to work?
https://github.com/AndrewQuijano/libosi/releases/tag/v0.0.5
https://github.com/AndrewQuijano/libosi/releases/tag/v0.0.15 (latest version)

![image](https://github.com/user-attachments/assets/9bf96dfd-608b-4196-8c71-2facb930b58c)

Also, I slightly updated CMakeLists.txt to use later versions, no issues. Moreover, I updated how it installs to more properly align with Debian Packaging standards, so now `/usr/lib/` is installed in `/usr/lib/x86_64-linux-gnu`, which is also required for `ldconfig` to work correctly.

[libosi_files.txt](https://github.com/user-attachments/files/18223219/libosi_files.txt)

I also needed to add `libglib2.0-dev` for Ubuntu 24 to fix this error:
![image](https://github.com/user-attachments/assets/c7e92d5f-133b-4088-9a02-cd07979b2f14)

P. S.
Ubuntu 20 runner got removed as of April 15, 2025

https://github.com/actions/runner-images/issues/11101